### PR TITLE
Corrected swedish translation of discharge 'Rate'

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -249,7 +249,7 @@ msgstr "%.1fV"
 #. TRANSLATORS: the rate of discharge for the device
 #: ../src/gpm-statistics.c:82 ../src/gpm-statistics.c:733
 msgid "Rate"
-msgstr "Frekvens"
+msgstr "Takt"
 
 #: ../src/gpm-statistics.c:83
 msgid "Charge"


### PR DESCRIPTION
The discharge rate has been incorrectly translated for a long time. A correct translation should be 'Takt' or possibly 'Hastighet'. Using 'Effekt' would also be correct but not correspond directly to the original term.
