### PR TITLE
Remove unnecesary cairo_set_source_rgb 

### DIFF
--- a/src/egg-graph-widget.c
+++ b/src/egg-graph-widget.c
@@ -506,7 +506,6 @@ egg_graph_widget_draw_labels (EggGraphWidget *graph, cairo_t *cr)
 	cairo_save (cr);
 
 	/* do x text */
-	cairo_set_source_rgb (cr, 0.2f, 0.2f, 0.2f);
 	for (i = 0; i < priv->divs_x + 1; i++) {
 		g_autofree gchar *text = NULL;
 		b = priv->box_x + ((gdouble) i * divwidth);


### PR DESCRIPTION
This cairo_set_source_rgb call was making the labels on the X and Y axis too dark to view on a lot of dark themes, even on Adwaita. Removing it makis the font a light gray-ish color wich can be seen on all themes, light or dark.

PS: Im sorry if I'm doing anything wrong with this PR as it is my first PR on an open-source project, but since I like this tool a lot, the same as I like dark themes, I took the time to fix it :)